### PR TITLE
Issue#1 Create Die class

### DIFF
--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -44,7 +44,7 @@ public class Die
     /// <summary>
     /// Gets the number of sides of the die.
     /// </summary>
-    public byte NumberOfSides { get; private set; }
+    public byte NumberOfSides { get; init; }
 
     /// <summary>
     /// The current face up value for the die

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -25,7 +25,7 @@ public class Die
     /// with the specified number of sides.
     /// </summary>
     /// <param name="numSides">
-    /// The number of sides for the die. Must be greater than zero.
+    /// The number of sides for the die. Must be greater than zero and up to <see cref="MAX_SIDES"/>.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when invalid number of sides is provided</exception>
     public Die(byte numSides)

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -39,4 +39,24 @@ public class Die
     /// Gets the number of sides of the die.
     /// </summary>
     public byte NumberOfSides { get; private set; }
+
+    /// <summary>
+    /// The current face up value for the die
+    /// </summary>
+    public byte FaceUpValue { get; private set; }
+
+    /// <summary>
+    /// Simulates rolling the die and returns the resulting face-up value.
+    /// </summary>
+    /// <remarks>The face-up value is randomly determined based on the number of sides of the die. The value
+    /// is updated internally and can be retrieved using the <see cref="FaceUpValue"/> property.</remarks>
+    /// <returns>A byte representing the face-up value of the die after the roll. The value will be between 1 and the number of
+    /// sides of the die, inclusive.</returns>
+    public byte Roll()
+    {
+        Random rand = new();
+        FaceUpValue = Convert.ToByte(rand.Next(1, NumberOfSides + 1));
+
+        return FaceUpValue;
+    }
 }

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -17,6 +17,7 @@ namespace DiceRoller;
 /// </remarks>
 public class Die
 {
+    private const byte MAX_SIDES = 20;
     private static readonly Random rand = new();
 
     /// <summary>
@@ -29,7 +30,7 @@ public class Die
     /// <exception cref="ArgumentOutOfRangeException">Thrown when invalid number of sides is provided</exception>
     public Die(byte numSides)
     {
-        if (numSides == 0 || numSides > 20)
+        if (numSides == 0 || numSides > MAX_SIDES)
         {
             throw new ArgumentOutOfRangeException(nameof(numSides)
                 , $"{nameof(numSides)} must be greater than 0 and less than 21");

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -17,6 +17,8 @@ namespace DiceRoller;
 /// </remarks>
 public class Die
 {
+    private static readonly Random rand = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Die"/> class 
     /// with the specified number of sides.
@@ -54,7 +56,6 @@ public class Die
     /// sides of the die, inclusive.</returns>
     public byte Roll()
     {
-        Random rand = new();
         FaceUpValue = Convert.ToByte(rand.Next(1, NumberOfSides + 1));
 
         return FaceUpValue;

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DiceRoller;
+
+/// <summary>
+/// Represents a die used in games or simulations, 
+/// with a configurable number of sides.
+/// </summary>
+/// <remarks>
+/// The <see cref="Die"/> class models a standard die, allowing 
+/// the number of sides to be specified. This can be used for games, 
+/// random number generation, or other scenarios requiring dice rolls.
+/// </remarks>
+public class Die
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Die"/> class 
+    /// with the specified number of sides.
+    /// </summary>
+    /// <param name="numSides">
+    /// The number of sides for the die. Must be greater than zero.
+    /// </param>
+    public Die(byte numSides)
+    {
+        if (numSides == 0 || numSides > 20)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numSides)
+                , $"{nameof(numSides)} must be greater than 0 and less than 21");
+        }
+        NumberOfSides = numSides;
+    }
+
+    /// <summary>
+    /// Gets the number of sides of the die.
+    /// </summary>
+    public byte NumberOfSides { get; private set; }
+}

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -35,6 +35,9 @@ public class Die
                 , $"{nameof(numSides)} must be greater than 0 and less than 21");
         }
         NumberOfSides = numSides;
+
+        // Forces the die to start as a random number
+        Roll();
     }
 
     /// <summary>

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DiceRoller;
 

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -24,6 +24,7 @@ public class Die
     /// <param name="numSides">
     /// The number of sides for the die. Must be greater than zero.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when invalid number of sides is provided</exception>
     public Die(byte numSides)
     {
         if (numSides == 0 || numSides > 20)

--- a/DiceRoller/Die.cs
+++ b/DiceRoller/Die.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace DiceRoller;
+﻿namespace DiceRoller;
 
 /// <summary>
 /// Represents a die used in games or simulations, 


### PR DESCRIPTION
Closes #1 

This pull request introduces a new `Die` class in the `DiceRoller` namespace to model a configurable die for games or simulations. The class provides functionality to specify the number of sides, roll the die, and retrieve the current face-up value.

### New `Die` class implementation:

* **Class overview**: The `Die` class represents a die with a configurable number of sides, supporting up to 20 sides. It includes properties and methods for rolling the die and retrieving its state. (`[DiceRoller/Die.csR1-R67](diffhunk://#diff-31c410d5128a6b483b1d7262472d647a3e7bb4f441ac1b71b5962b3d722d8902R1-R67)`)
* **Constructor**: Validates the number of sides provided (must be between 1 and 20) and initializes the die with a random face-up value. (`[DiceRoller/Die.csR1-R67](diffhunk://#diff-31c410d5128a6b483b1d7262472d647a3e7bb4f441ac1b71b5962b3d722d8902R1-R67)`)
* **Properties**:
  - [`NumberOfSides`](diffhunk://#diff-31c410d5128a6b483b1d7262472d647a3e7bb4f441ac1b71b5962b3d722d8902R1-R67): Read-only property specifying the number of sides of the die. (`[DiceRoller/Die.csR1-R67](diffhunk://#diff-31c410d5128a6b483b1d7262472d647a3e7bb4f441ac1b71b5962b3d722d8902R1-R67)`)
  - [`FaceUpValue`](diffhunk://#diff-31c410d5128a6b483b1d7262472d647a3e7bb4f441ac1b71b5962b3d722d8902R1-R67): Read-only property storing the current face-up value after a roll. (`[DiceRoller/Die.csR1-R67](diffhunk://#diff-31c410d5128a6b483b1d7262472d647a3e7bb4f441ac1b71b5962b3d722d8902R1-R67)`)
* **Method**: 
  - [`Roll()`](diffhunk://#diff-31c410d5128a6b483b1d7262472d647a3e7bb4f441ac1b71b5962b3d722d8902R1-R67): Simulates rolling the die, updates the `FaceUpValue`, and returns the result. (`[DiceRoller/Die.csR1-R67](diffhunk://#diff-31c410d5128a6b483b1d7262472d647a3e7bb4f441ac1b71b5962b3d722d8902R1-R67)`)